### PR TITLE
feat: add projects table

### DIFF
--- a/src/sql/projects.sql
+++ b/src/sql/projects.sql
@@ -1,0 +1,7 @@
+-- Create a table to track lab projects
+CREATE TABLE IF NOT EXISTS projects (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    created_at TIMESTAMP DEFAULT NOW()
+);


### PR DESCRIPTION
This PR adds a new `projects` table to support lab project tracking.

Table definition (`projects`):
- `id` (SERIAL PRIMARY KEY)
- `name` (TEXT NOT NULL)
- `description` (TEXT)
- `created_at` (TIMESTAMP DEFAULT NOW())

Closes #5